### PR TITLE
Fix same level arrows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggflowchart
 Title: Flowcharts with 'ggplot2'
-Version: 1.0.0.9001
+Version: 1.0.0.9002
 Authors@R: 
     person(given = "Nicola",
            family = "Rennie",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-## ggflowchart 1.0.0.9001 2023_05_20
+## ggflowchart 1.0.0.9002 2023_05_20
+
+* Fix pkgdown site missing vignette
+* Same level arrows support (issue #5)
+
+## ggflowchart 1.0.0.9001 2023_05_19
 
 * Add vignette on how to style nodes
 * Add initial unit testing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,9 @@
-## ggflowchart 1.0.0.9002 2023_05_20
+## ggflowchart 1.0.0.9000+ 2023_05_19
 
-* Fix pkgdown site missing vignette
 * Same level arrows support (issue #5)
-
-## ggflowchart 1.0.0.9001 2023_05_19
-
 * Add vignette on how to style nodes
 * Add initial unit testing
 * Add utils function to determine arrow type
-
-## ggflowchart 1.0.0.9000 2023_05_19
-
 * Add ability to add arrow labels (issue #15)
 * Add `arrow_linewidth` and `arrow_linewidth` as arguments (issue #14)
 * Add lintr checks to GH Actions

--- a/R/arrow_direction.R
+++ b/R/arrow_direction.R
@@ -23,9 +23,9 @@ single_arrow_direction <- function(plot_nodes,
   } else if (y_diff == 0 && x_diff < 0) {
     return("rl")
   } else if (y_diff > 0) {
-    return("bt")
+    return("up")
   } else {
-    return("tb")
+    return("down")
   }
 }
 

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -25,14 +25,16 @@ get_edges <- function(data, plot_nodes, node_layout) {
     plot_nodes = plot_nodes,
     node_layout = node_layout
     )
-  # compute start and end points
-  plot_edges <- data %>%
+  # compute start and end points for each type of edge
+  # Downwards (default)
+  plot_edge_down <- edge_type_data %>%
+    dplyr::filter(.data$arrow_direction == "down") %>%
     dplyr::select(c(.data$from, .data$to)) %>%
-    dplyr::mutate(id = dplyr::row_number()) %>%
+    dplyr::mutate(id = paste("down", dplyr::row_number())) %>%
     tidyr::pivot_longer(cols = c("from", "to"),
                         names_to = "s_e",
                         values_to = "name") %>%
-    dplyr::left_join(plot_nodes, by = "name") %>%
+    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
     dplyr::select(-c(.data$y,
                      .data$xmin,
                      .data$xmax)) %>%
@@ -41,5 +43,63 @@ get_edges <- function(data, plot_nodes, node_layout) {
                              .data$ymax)) %>%
     dplyr::select(-c(.data$ymin,
                      .data$ymax))
+  # Upwards - to do
+  plot_edge_up <- edge_type_data %>%
+    dplyr::filter(.data$arrow_direction == "up") %>%
+    dplyr::select(c(.data$from, .data$to)) %>%
+    dplyr::mutate(id = paste("up", dplyr::row_number())) %>%
+    tidyr::pivot_longer(cols = c("from", "to"),
+                        names_to = "s_e",
+                        values_to = "name") %>%
+    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
+    dplyr::select(-c(.data$y,
+                     .data$xmin,
+                     .data$xmax)) %>%
+    dplyr::mutate(y = ifelse(.data$s_e == "from",
+                             .data$ymin,
+                             .data$ymax)) %>%
+    dplyr::select(-c(.data$ymin,
+                     .data$ymax))
+  # Left to right
+  plot_edge_lr <- edge_type_data %>%
+    dplyr::filter(.data$arrow_direction == "lr") %>%
+    dplyr::select(c(.data$from, .data$to)) %>%
+    dplyr::mutate(id = paste("lr", dplyr::row_number())) %>%
+    tidyr::pivot_longer(cols = c("from", "to"),
+                        names_to = "s_e",
+                        values_to = "name") %>%
+    dplyr::left_join(
+      dplyr::select(plot_nodes, -c(x_nudge, y_nudge)),
+      by = "name"
+    ) %>%
+    dplyr::select(-c(.data$x,
+                     .data$ymin,
+                     .data$ymax)) %>%
+    dplyr::mutate(x = ifelse(.data$s_e == "from",
+                             .data$xmax,
+                             .data$xmin)) %>%
+    dplyr::select(-c(.data$xmin,
+                     .data$xmax))
+  # right to left - to do
+  plot_edge_rl <- edge_type_data %>%
+    dplyr::filter(.data$arrow_direction == "rl") %>%
+    dplyr::select(c(.data$from, .data$to)) %>%
+    dplyr::mutate(id = paste("rl", dplyr::row_number())) %>%
+    tidyr::pivot_longer(cols = c("from", "to"),
+                        names_to = "s_e",
+                        values_to = "name") %>%
+    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
+    dplyr::select(-c(.data$y,
+                     .data$xmin,
+                     .data$xmax)) %>%
+    dplyr::mutate(y = ifelse(.data$s_e == "from",
+                             .data$ymin,
+                             .data$ymax)) %>%
+    dplyr::select(-c(.data$ymin,
+                     .data$ymax))
+  # join data set together
+  plot_edges <- rbind(
+    plot_edge_up, plot_edge_down, plot_edge_rl, plot_edge_lr
+    )
   return(plot_edges)
 }

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -80,7 +80,7 @@ get_edges <- function(data, plot_nodes, node_layout) {
                              .data$xmin)) %>%
     dplyr::select(-c(.data$xmin,
                      .data$xmax))
-  # right to left - to do
+  # right to left
   plot_edge_rl <- edge_type_data %>%
     dplyr::filter(.data$arrow_direction == "rl") %>%
     dplyr::select(c(.data$from, .data$to)) %>%
@@ -88,15 +88,18 @@ get_edges <- function(data, plot_nodes, node_layout) {
     tidyr::pivot_longer(cols = c("from", "to"),
                         names_to = "s_e",
                         values_to = "name") %>%
-    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
-    dplyr::select(-c(.data$y,
-                     .data$xmin,
-                     .data$xmax)) %>%
-    dplyr::mutate(y = ifelse(.data$s_e == "from",
-                             .data$ymin,
-                             .data$ymax)) %>%
-    dplyr::select(-c(.data$ymin,
-                     .data$ymax))
+    dplyr::left_join(
+      dplyr::select(plot_nodes, -c(x_nudge, y_nudge)),
+      by = "name"
+    ) %>%
+    dplyr::select(-c(.data$x,
+                     .data$ymin,
+                     .data$ymax)) %>%
+    dplyr::mutate(x = ifelse(.data$s_e == "from",
+                             .data$xmin,
+                             .data$xmax)) %>%
+    dplyr::select(-c(.data$xmin,
+                     .data$xmax))
   # join data set together
   plot_edges <- rbind(
     plot_edge_up, plot_edge_down, plot_edge_rl, plot_edge_lr

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -43,7 +43,7 @@ get_edges <- function(data, plot_nodes, node_layout) {
                              .data$ymax)) %>%
     dplyr::select(-c(.data$ymin,
                      .data$ymax))
-  # Upwards - to do
+  # Upwards
   plot_edge_up <- edge_type_data %>%
     dplyr::filter(.data$arrow_direction == "up") %>%
     dplyr::select(c(.data$from, .data$to)) %>%
@@ -56,8 +56,8 @@ get_edges <- function(data, plot_nodes, node_layout) {
                      .data$xmin,
                      .data$xmax)) %>%
     dplyr::mutate(y = ifelse(.data$s_e == "from",
-                             .data$ymin,
-                             .data$ymax)) %>%
+                             .data$ymax,
+                             .data$ymin)) %>%
     dplyr::select(-c(.data$ymin,
                      .data$ymax))
   # Left to right

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -6,18 +6,26 @@
 #' and "to" it is assumed first column are "from" node names,
 #' second column is "to" node names. Node names must be unique.
 #' @param plot_nodes Tibble of node coordinates output from \code{get_nodes()}.
+#' @param node_layout Data frame of node layout returned by \code{get_layout()}
 #' @importFrom dplyr %>%
 #' @importFrom rlang .data
 #' @return A tibble.
 #' @noRd
 
-get_edges <- function(data, plot_nodes) {
+get_edges <- function(data, plot_nodes, node_layout) {
   if (ncol(data) < 2) {
     stop("Incorrect number of columns in data: input data should contain at least two columns.")
   }
   if (!all(c("from", "to") %in% colnames(data))) {
     colnames(data)[1:2] <- c("from", "to")
   }
+  # define edge types
+  edge_type_data <- arrow_direction(
+    data = data,
+    plot_nodes = plot_nodes,
+    node_layout = node_layout
+    )
+  # compute start and end points
   plot_edges <- data %>%
     dplyr::select(c(.data$from, .data$to)) %>%
     dplyr::mutate(id = dplyr::row_number()) %>%

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -34,7 +34,10 @@ get_edges <- function(data, plot_nodes, node_layout) {
     tidyr::pivot_longer(cols = c("from", "to"),
                         names_to = "s_e",
                         values_to = "name") %>%
-    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
+    dplyr::left_join(
+      dplyr::select(plot_nodes, -c(.data$x_nudge, .data$y_nudge)),
+      by = "name"
+      ) %>%
     dplyr::select(-c(.data$y,
                      .data$xmin,
                      .data$xmax)) %>%
@@ -51,7 +54,10 @@ get_edges <- function(data, plot_nodes, node_layout) {
     tidyr::pivot_longer(cols = c("from", "to"),
                         names_to = "s_e",
                         values_to = "name") %>%
-    dplyr::left_join(dplyr::select(plot_nodes, -c(x_nudge, y_nudge)), by = "name") %>%
+    dplyr::left_join(
+      dplyr::select(plot_nodes, -c(.data$x_nudge, .data$y_nudge)),
+      by = "name"
+      ) %>%
     dplyr::select(-c(.data$y,
                      .data$xmin,
                      .data$xmax)) %>%
@@ -69,7 +75,9 @@ get_edges <- function(data, plot_nodes, node_layout) {
                         names_to = "s_e",
                         values_to = "name") %>%
     dplyr::left_join(
-      dplyr::select(plot_nodes, -c(x_nudge, y_nudge)),
+      dplyr::select(
+        plot_nodes, -c(.data$x_nudge, .data$y_nudge)
+        ),
       by = "name"
     ) %>%
     dplyr::select(-c(.data$x,
@@ -89,7 +97,7 @@ get_edges <- function(data, plot_nodes, node_layout) {
                         names_to = "s_e",
                         values_to = "name") %>%
     dplyr::left_join(
-      dplyr::select(plot_nodes, -c(x_nudge, y_nudge)),
+      dplyr::select(plot_nodes, -c(.data$x_nudge, .data$y_nudge)),
       by = "name"
     ) %>%
     dplyr::select(-c(.data$x,

--- a/R/ggflowchart.R
+++ b/R/ggflowchart.R
@@ -97,7 +97,8 @@ ggflowchart <- function(data,
   # define arrows
   plot_edges <- get_edges(
     data = data,
-    plot_nodes = plot_nodes
+    plot_nodes = plot_nodes,
+    node_layout = node_layout
   )
   # define edge labels
   edge_labels <- get_edge_labels(

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ggflowchart(data)
 
 ![](man/figures/README-minimal.png)
 
-See vignettes for further examples of usage.
+See [vignettes](https://nrennie.github.io/ggflowchart/articles/) for further examples of usage.
 
 ## Upcoming features
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,3 +8,4 @@ articles:
   contents:
   - minimal-example
   - decision-tree-example
+  - style-nodes


### PR DESCRIPTION
Adds support for same level arrows. Closes #5.

```r
data <- tibble::tibble(
  from = c("A", "A", "A", "B", "C", "F", "C", "C", "G"),
  to = c("B", "C", "D", "E", "F", "G", "B", "D", "E")
  )
ggflowchart(data)
```

![Rplot](https://github.com/nrennie/ggflowchart/assets/42338476/f558d761-3394-4364-bba1-edad1f0e12da)
